### PR TITLE
Add compaction support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,5 +23,5 @@ RUN bin/installDeps.sh && rm -rf ~/.npm && \
         pnpm run install-plugins ${ETHERPAD_LOCAL_PLUGINS:+--path ${ETHERPAD_LOCAL_PLUGINS}}; \
     fi
 # Workaround for Error: Cannot find module 'web-streams-polyfill'(maybe version conflict)
-RUN cd /opt/etherpad-lite/src && pnpm i web-streams-polyfill@3.3.3
+RUN cd /opt/etherpad-lite/src && pnpm i web-streams-polyfill@3.3.3 sharp@latest
 COPY --chown=etherpad demo/installed_plugins.json /opt/etherpad-lite/var/

--- a/demo/settings.json
+++ b/demo/settings.json
@@ -658,6 +658,16 @@
       "default": "gpt-4",
       "forImage": "gpt-4-vision-preview"
     },
-    "apiKey": "DUMMY_TOKEN"
+    "apiKey": "DUMMY_TOKEN",
+    "compaction": {
+      "maxImageSize": {
+        "width": 480,
+        "height": 480
+      },
+      "maxContentLength": {
+        "beforeLength": 20480,
+        "afterLength": 1024
+      }
+    }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,12 +6,13 @@
   "packages": {
     "": {
       "name": "ep_kodama",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "dependencies": {
         "express": "^4.19.2",
         "ms": "^2.1.3",
         "node-fetch": "^3.3.2",
         "openai": "^4.32.1",
+        "sharp": "^0.33.4",
         "web-streams-polyfill": "^3.3.3"
       },
       "devDependencies": {
@@ -1098,6 +1099,21 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true
     },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.1.1.tgz",
+      "integrity": "sha512-3bfqkzuR1KLx57nZfjr2NLnFOobvyS0aTszaEGCGqmYMVDRaGvgIZbjGSV/MHSSmLgQ/b9JFHQ5xm5WRZYd+XQ==",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime/node_modules/tslib": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
+      "optional": true
+    },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz",
@@ -1186,6 +1202,437 @@
       "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.3.tgz",
       "integrity": "sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==",
       "dev": true
+    },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.33.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.33.4.tgz",
+      "integrity": "sha512-p0suNqXufJs9t3RqLBO6vvrgr5OhgbWp76s5gTRvdmxmuv9E1rcaqGUsl3l4mKVmXPkTkTErXediAui4x+8PSA==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "glibc": ">=2.26",
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0",
+        "npm": ">=9.6.5",
+        "pnpm": ">=7.1.0",
+        "yarn": ">=3.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.0.2"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.33.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.33.4.tgz",
+      "integrity": "sha512-0l7yRObwtTi82Z6ebVI2PnHT8EB2NxBgpK2MiKJZJ7cz32R4lxd001ecMhzzsZig3Yv9oclvqqdV93jo9hy+Dw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "glibc": ">=2.26",
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0",
+        "npm": ">=9.6.5",
+        "pnpm": ">=7.1.0",
+        "yarn": ">=3.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.0.2"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.0.2.tgz",
+      "integrity": "sha512-tcK/41Rq8IKlSaKRCCAuuY3lDJjQnYIW1UXU1kxcEKrfL8WR7N6+rzNoOxoQRJWTAECuKwgAHnPvqXGN8XfkHA==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "macos": ">=11",
+        "npm": ">=9.6.5",
+        "pnpm": ">=7.1.0",
+        "yarn": ">=3.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.0.2.tgz",
+      "integrity": "sha512-Ofw+7oaWa0HiiMiKWqqaZbaYV3/UGL2wAPeLuJTx+9cXpCRdvQhCLG0IH8YGwM0yGWGLpsF4Su9vM1o6aer+Fw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "macos": ">=10.13",
+        "npm": ">=9.6.5",
+        "pnpm": ">=7.1.0",
+        "yarn": ">=3.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.0.2.tgz",
+      "integrity": "sha512-iLWCvrKgeFoglQxdEwzu1eQV04o8YeYGFXtfWU26Zr2wWT3q3MTzC+QTCO3ZQfWd3doKHT4Pm2kRmLbupT+sZw==",
+      "cpu": [
+        "arm"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "glibc": ">=2.28",
+        "npm": ">=9.6.5",
+        "pnpm": ">=7.1.0",
+        "yarn": ">=3.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.0.2.tgz",
+      "integrity": "sha512-x7kCt3N00ofFmmkkdshwj3vGPCnmiDh7Gwnd4nUwZln2YjqPxV1NlTyZOvoDWdKQVDL911487HOueBvrpflagw==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "glibc": ">=2.26",
+        "npm": ">=9.6.5",
+        "pnpm": ">=7.1.0",
+        "yarn": ">=3.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.0.2.tgz",
+      "integrity": "sha512-cmhQ1J4qVhfmS6szYW7RT+gLJq9dH2i4maq+qyXayUSn9/3iY2ZeWpbAgSpSVbV2E1JUL2Gg7pwnYQ1h8rQIog==",
+      "cpu": [
+        "s390x"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "glibc": ">=2.28",
+        "npm": ">=9.6.5",
+        "pnpm": ">=7.1.0",
+        "yarn": ">=3.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.0.2.tgz",
+      "integrity": "sha512-E441q4Qdb+7yuyiADVi5J+44x8ctlrqn8XgkDTwr4qPJzWkaHwD489iZ4nGDgcuya4iMN3ULV6NwbhRZJ9Z7SQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "glibc": ">=2.26",
+        "npm": ">=9.6.5",
+        "pnpm": ">=7.1.0",
+        "yarn": ">=3.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.0.2.tgz",
+      "integrity": "sha512-3CAkndNpYUrlDqkCM5qhksfE+qSIREVpyoeHIU6jd48SJZViAmznoQQLAv4hVXF7xyUB9zf+G++e2v1ABjCbEQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "musl": ">=1.2.2",
+        "npm": ">=9.6.5",
+        "pnpm": ">=7.1.0",
+        "yarn": ">=3.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.0.2.tgz",
+      "integrity": "sha512-VI94Q6khIHqHWNOh6LLdm9s2Ry4zdjWJwH56WoiJU7NTeDwyApdZZ8c+SADC8OH98KWNQXnE01UdJ9CSfZvwZw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "musl": ">=1.2.2",
+        "npm": ">=9.6.5",
+        "pnpm": ">=7.1.0",
+        "yarn": ">=3.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.33.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.33.4.tgz",
+      "integrity": "sha512-RUgBD1c0+gCYZGCCe6mMdTiOFS0Zc/XrN0fYd6hISIKcDUbAW5NtSQW9g/powkrXYm6Vzwd6y+fqmExDuCdHNQ==",
+      "cpu": [
+        "arm"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "glibc": ">=2.28",
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0",
+        "npm": ">=9.6.5",
+        "pnpm": ">=7.1.0",
+        "yarn": ">=3.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.0.2"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.33.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.33.4.tgz",
+      "integrity": "sha512-2800clwVg1ZQtxwSoTlHvtm9ObgAax7V6MTAB/hDT945Tfyy3hVkmiHpeLPCKYqYR1Gcmv1uDZ3a4OFwkdBL7Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "glibc": ">=2.26",
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0",
+        "npm": ">=9.6.5",
+        "pnpm": ">=7.1.0",
+        "yarn": ">=3.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.0.2"
+      }
+    },
+    "node_modules/@img/sharp-linux-s390x": {
+      "version": "0.33.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.33.4.tgz",
+      "integrity": "sha512-h3RAL3siQoyzSoH36tUeS0PDmb5wINKGYzcLB5C6DIiAn2F3udeFAum+gj8IbA/82+8RGCTn7XW8WTFnqag4tQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "glibc": ">=2.31",
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0",
+        "npm": ">=9.6.5",
+        "pnpm": ">=7.1.0",
+        "yarn": ">=3.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.0.2"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.33.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.33.4.tgz",
+      "integrity": "sha512-GoR++s0XW9DGVi8SUGQ/U4AeIzLdNjHka6jidVwapQ/JebGVQIpi52OdyxCNVRE++n1FCLzjDovJNozif7w/Aw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "glibc": ">=2.26",
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0",
+        "npm": ">=9.6.5",
+        "pnpm": ">=7.1.0",
+        "yarn": ">=3.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.0.2"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.33.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.33.4.tgz",
+      "integrity": "sha512-nhr1yC3BlVrKDTl6cO12gTpXMl4ITBUZieehFvMntlCXFzH2bvKG76tBL2Y/OqhupZt81pR7R+Q5YhJxW0rGgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "musl": ">=1.2.2",
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0",
+        "npm": ">=9.6.5",
+        "pnpm": ">=7.1.0",
+        "yarn": ">=3.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.0.2"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.33.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.33.4.tgz",
+      "integrity": "sha512-uCPTku0zwqDmZEOi4ILyGdmW76tH7dm8kKlOIV1XC5cLyJ71ENAAqarOHQh0RLfpIpbV5KOpXzdU6XkJtS0daw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "musl": ">=1.2.2",
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0",
+        "npm": ">=9.6.5",
+        "pnpm": ">=7.1.0",
+        "yarn": ">=3.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.0.2"
+      }
+    },
+    "node_modules/@img/sharp-wasm32": {
+      "version": "0.33.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.33.4.tgz",
+      "integrity": "sha512-Bmmauh4sXUsUqkleQahpdNXKvo+wa1V9KhT2pDA4VJGKwnKMJXiSTGphn0gnJrlooda0QxCtXc6RX1XAU6hMnQ==",
+      "cpu": [
+        "wasm32"
+      ],
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.1.1"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0",
+        "npm": ">=9.6.5",
+        "pnpm": ">=7.1.0",
+        "yarn": ">=3.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-ia32": {
+      "version": "0.33.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.33.4.tgz",
+      "integrity": "sha512-99SJ91XzUhYHbx7uhK3+9Lf7+LjwMGQZMDlO/E/YVJ7Nc3lyDFZPGhjwiYdctoH2BOzW9+TnfqcaMKt0jHLdqw==",
+      "cpu": [
+        "ia32"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0",
+        "npm": ">=9.6.5",
+        "pnpm": ">=7.1.0",
+        "yarn": ">=3.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.33.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.33.4.tgz",
+      "integrity": "sha512-3QLocdTRVIrFNye5YocZl+KKpYKP+fksi1QhmOArgx7GyhIbQp/WrJRu176jm8IxromS7RIkzMiMINVdBtC8Aw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0",
+        "npm": ">=9.6.5",
+        "pnpm": ">=7.1.0",
+        "yarn": ">=3.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
     },
     "node_modules/@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
@@ -3462,6 +3909,18 @@
       "integrity": "sha512-lHl4d5/ONEbLlJvaJNtsF/Lz+WvB07u2ycqTYbdrq7UypDXailES4valYb2eWiJFxZlVmpGekfqoxQhzyFdT4Q==",
       "dev": true
     },
+    "node_modules/color": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
+      "integrity": "sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==",
+      "dependencies": {
+        "color-convert": "^2.0.1",
+        "color-string": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=12.5.0"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -3477,6 +3936,15 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+    },
+    "node_modules/color-string": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
+      "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
+      "dependencies": {
+        "color-name": "^1.0.0",
+        "simple-swizzle": "^0.2.2"
+      }
     },
     "node_modules/combined-stream": {
       "version": "1.0.8",
@@ -3891,8 +4359,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.3.tgz",
       "integrity": "sha512-bwy0MGW55bG41VqxxypOsdSdGqLwXPI/focwgTYCFMbdUiBAxLg9CFzG08sz2aqzknwiX7Hkl0bQENjg8iLByw==",
-      "optional": true,
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -15002,6 +15468,56 @@
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="
     },
+    "node_modules/sharp": {
+      "version": "0.33.4",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.33.4.tgz",
+      "integrity": "sha512-7i/dt5kGl7qR4gwPRD2biwD2/SvBn3O04J77XKFgL2OnZtQw+AG9wnuS/csmu80nPRHLYE9E41fyEiG8nhH6/Q==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "color": "^4.2.3",
+        "detect-libc": "^2.0.3",
+        "semver": "^7.6.0"
+      },
+      "engines": {
+        "libvips": ">=8.15.2",
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.33.4",
+        "@img/sharp-darwin-x64": "0.33.4",
+        "@img/sharp-libvips-darwin-arm64": "1.0.2",
+        "@img/sharp-libvips-darwin-x64": "1.0.2",
+        "@img/sharp-libvips-linux-arm": "1.0.2",
+        "@img/sharp-libvips-linux-arm64": "1.0.2",
+        "@img/sharp-libvips-linux-s390x": "1.0.2",
+        "@img/sharp-libvips-linux-x64": "1.0.2",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.0.2",
+        "@img/sharp-libvips-linuxmusl-x64": "1.0.2",
+        "@img/sharp-linux-arm": "0.33.4",
+        "@img/sharp-linux-arm64": "0.33.4",
+        "@img/sharp-linux-s390x": "0.33.4",
+        "@img/sharp-linux-x64": "0.33.4",
+        "@img/sharp-linuxmusl-arm64": "0.33.4",
+        "@img/sharp-linuxmusl-x64": "0.33.4",
+        "@img/sharp-wasm32": "0.33.4",
+        "@img/sharp-win32-ia32": "0.33.4",
+        "@img/sharp-win32-x64": "0.33.4"
+      }
+    },
+    "node_modules/sharp/node_modules/semver": {
+      "version": "7.6.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
+      "integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -15105,6 +15621,19 @@
         "type": "github",
         "url": "https://github.com/sponsors/steveukx/"
       }
+    },
+    "node_modules/simple-swizzle": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
+      "integrity": "sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==",
+      "dependencies": {
+        "is-arrayish": "^0.3.1"
+      }
+    },
+    "node_modules/simple-swizzle/node_modules/is-arrayish": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
+      "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ=="
     },
     "node_modules/sisteransi": {
       "version": "1.0.5",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "ms": "^2.1.3",
     "node-fetch": "^3.3.2",
     "openai": "^4.32.1",
+    "sharp": "^0.33.4",
     "web-streams-polyfill": "^3.3.3"
   },
   "engines": {

--- a/src/common/@types/ep_etherpad-lite/node/utils/Settings.d.ts
+++ b/src/common/@types/ep_etherpad-lite/node/utils/Settings.d.ts
@@ -2,11 +2,23 @@ declare module "ep_etherpad-lite/node/utils/Settings" {
   export type APIModel = {
     default: string;
     forImage?: string;
-  }
+  };
+
+  export type CompactionSettings = {
+    maxImageSize?: {
+      width: number;
+      height: number;
+    };
+    maxContentLength?: {
+      beforeLength?: number;
+      afterLength?: number;
+    };
+  };
 
   export const ep_kodama: {
     api?: string;
     apiKey?: string;
     apiModel?: APIModel | string;
+    compaction?: CompactionSettings;
   };
 }

--- a/src/completion/compaction.ts
+++ b/src/completion/compaction.ts
@@ -1,0 +1,236 @@
+import { CompactionSettings, PluginSettings } from "./settings";
+import {
+  CompletionService,
+  CompletionQuery,
+  CompletionContentType,
+  CompletionContent,
+} from "./base";
+
+const logPrefix = "[ep_kodama]";
+
+const DEFAULT_MAX_IMAGE_SIZE = {
+  width: 512,
+  height: 512,
+};
+
+const DEFAULT_MAX_CONTENT_LENGTH = {
+  beforeLength: 1024 * 20,
+  afterLength: 1024,
+};
+
+const MARKER_PATTERN = /\<input\s+\S+\s+here\>/;
+
+async function performImageCompaction(
+  compactionSettings: CompactionSettings,
+  content: CompletionContent
+): Promise<CompletionContent> {
+  if (content.type !== CompletionContentType.Image) {
+    throw new Error(`Expected image content, got ${content.type}`);
+  }
+  if (compactionSettings.maxImageSize === undefined) {
+    // compaction disabled
+    return content;
+  }
+  let sharp;
+  try {
+    sharp = (await import("sharp")).default;
+  } catch (err) {
+    console.warn(
+      logPrefix,
+      "sharp is required for image compaction. skipped.",
+      err
+    );
+    return content;
+  }
+  const imageSize = compactionSettings.maxImageSize;
+  const dataURL = content.value;
+  // convert dataURL to buffer
+  const buffer = Buffer.from(dataURL.split(",")[1], "base64");
+
+  const resizedBuffer = await sharp(buffer)
+    .resize(imageSize.width, imageSize.height, {
+      fit: "inside",
+      withoutEnlargement: true,
+    })
+    .png()
+    .toBuffer();
+  const resizedDataURL = `data:image/png;base64,${resizedBuffer.toString(
+    "base64"
+  )}`;
+  return {
+    type: CompletionContentType.Image,
+    value: resizedDataURL,
+  };
+}
+
+async function performCompaction(
+  compactionSettings: CompactionSettings,
+  content: CompletionContent
+): Promise<CompletionContent> {
+  if (content.type === CompletionContentType.Image) {
+    return performImageCompaction(compactionSettings, content);
+  }
+  return content;
+}
+
+function trimBefore(
+  contents: CompletionContent[],
+  beforeLength: number
+): CompletionContent[] {
+  const markerIndex = contents.findIndex(
+    (content) =>
+      content.type === CompletionContentType.Text &&
+      content.value.search(MARKER_PATTERN) !== -1
+  );
+  if (markerIndex === -1) {
+    throw new Error("No markers found");
+  }
+  const markerContent = contents[markerIndex];
+  const markerText = markerContent.value;
+  const markerPos = markerText.search(MARKER_PATTERN);
+  if (markerPos > beforeLength) {
+    const trimmedContent = {
+      type: CompletionContentType.Text,
+      value: markerText.substring(markerPos - beforeLength),
+    };
+    return [trimmedContent].concat(contents.slice(markerIndex + 1));
+  }
+  const remainingLength = beforeLength - markerPos;
+  return tail(contents.slice(0, markerIndex), remainingLength).concat(
+    contents.slice(markerIndex)
+  );
+}
+
+function trimAfter(
+  contents: CompletionContent[],
+  afterLength: number
+): CompletionContent[] {
+  const markerIndex = contents.findIndex(
+    (content) =>
+      content.type === CompletionContentType.Text &&
+      content.value.search(MARKER_PATTERN) !== -1
+  );
+  if (markerIndex === -1) {
+    throw new Error("No markers found");
+  }
+  const markerContent = contents[markerIndex];
+  const markerText = markerContent.value;
+  const markerPos = markerText.search(MARKER_PATTERN);
+  const markerMatch = markerText.substring(markerPos).match(MARKER_PATTERN);
+  if (markerMatch === null) {
+    throw new Error("Marker not found in marker content");
+  }
+  const markerEnd = markerPos + markerMatch[0].length;
+  if (markerText.length - markerEnd > afterLength) {
+    const trimmedContent = {
+      type: CompletionContentType.Text,
+      value: markerText.substring(0, markerEnd + afterLength),
+    };
+    return contents.slice(0, markerIndex).concat([trimmedContent]);
+  }
+  const remainingLength = afterLength - (markerText.length - markerEnd);
+  return contents
+    .slice(0, markerIndex + 1)
+    .concat(head(contents.slice(markerIndex + 1), remainingLength));
+}
+
+function head(
+  contents: CompletionContent[],
+  remainingLength: number
+): CompletionContent[] {
+  if (contents.length === 0) {
+    return contents;
+  }
+  const firstContent = contents[0];
+  if (firstContent.value.length > remainingLength) {
+    if (firstContent.type === CompletionContentType.Image) {
+      // cannot trim image content
+      return [];
+    }
+    const trimmedContent = {
+      type: CompletionContentType.Text,
+      value: firstContent.value.substring(0, remainingLength),
+    };
+    return [trimmedContent];
+  }
+  return [firstContent].concat(
+    head(contents.slice(1), remainingLength - firstContent.value.length)
+  );
+}
+
+function tail(
+  contents: CompletionContent[],
+  remainingLength: number
+): CompletionContent[] {
+  if (contents.length === 0) {
+    return contents;
+  }
+  const lastContent = contents[contents.length - 1];
+  if (lastContent.value.length > remainingLength) {
+    if (lastContent.type === CompletionContentType.Image) {
+      // cannot trim image content
+      return [];
+    }
+    const trimmedContent = {
+      type: CompletionContentType.Text,
+      value: lastContent.value.substring(
+        lastContent.value.length - remainingLength
+      ),
+    };
+    return [trimmedContent];
+  }
+  return tail(
+    contents.slice(0, -1),
+    remainingLength - lastContent.value.length
+  ).concat([lastContent]);
+}
+
+function trimContent(
+  compactionSettings: CompactionSettings,
+  contents: CompletionContent[]
+): CompletionContent[] {
+  if (compactionSettings.maxContentLength === undefined) {
+    return contents;
+  }
+  const { beforeLength, afterLength } = compactionSettings.maxContentLength;
+  let result = contents;
+  if (beforeLength !== undefined) {
+    result = trimBefore(result, beforeLength);
+  }
+  if (afterLength !== undefined) {
+    result = trimAfter(result, afterLength);
+  }
+  return result;
+}
+
+export class CompletionServiceWithCompaction implements CompletionService {
+  private pluginSettings: PluginSettings;
+
+  private completionService: CompletionService;
+
+  constructor(
+    pluginSettings: PluginSettings,
+    completionService: CompletionService
+  ) {
+    this.pluginSettings = pluginSettings;
+    this.completionService = completionService;
+  }
+
+  async completion(query: CompletionQuery): Promise<string> {
+    const { compaction } = this.pluginSettings;
+    const compactionSettings = compaction ?? {
+      maxImageSize: DEFAULT_MAX_IMAGE_SIZE,
+      maxContentLength: DEFAULT_MAX_CONTENT_LENGTH,
+    };
+    const compactedQueryContents = query.content.map((content) =>
+      performCompaction(compactionSettings, content)
+    );
+    const compactedQuery = await Promise.all(compactedQueryContents);
+    console.debug(logPrefix, "image compacted query:", compactedQuery);
+    const trimmedQuery = {
+      content: trimContent(compactionSettings, compactedQuery),
+    };
+    console.debug(logPrefix, "trimmed query:", trimmedQuery);
+    return this.completionService.completion(trimmedQuery);
+  }
+}

--- a/src/completion/openai.ts
+++ b/src/completion/openai.ts
@@ -9,6 +9,8 @@ import {
 import { ChatCompletionContentPart } from "openai/resources";
 import { APIModel } from "ep_etherpad-lite/node/utils/Settings";
 
+const logPrefix = "[ep_kodama]";
+
 const DEFAULT_API_MODEL = "gpt-3.5-turbo";
 
 function convertCompletionContent(
@@ -83,6 +85,9 @@ export class OpenAICompletionService {
         apiModel
       );
     }
+    console.debug(logPrefix, "OpenAI model:", apiModelName);
+    console.debug(logPrefix, "Image support:", imageSupport);
+    console.debug(logPrefix, "Query:", query);
     const completion = await openai.chat.completions.create({
       model: apiModelName,
       messages: [
@@ -115,7 +120,7 @@ export class OpenAICompletionService {
     if (!result) {
       throw new Error("OpenAI response is empty");
     }
-    console.log("OpenAI response:", result);
+    console.debug("OpenAI response:", result);
     return result;
   }
 }

--- a/src/completion/settings.ts
+++ b/src/completion/settings.ts
@@ -1,5 +1,22 @@
+export type APIModel = {
+  default: string;
+  forImage?: string;
+};
+
+export type CompactionSettings = {
+  maxImageSize?: {
+    width: number;
+    height: number;
+  };
+  maxContentLength?: {
+    beforeLength?: number;
+    afterLength?: number;
+  };
+};
+
 export type PluginSettings = {
   api?: string;
   apiKey?: string;
-  apiModel?: string;
+  apiModel?: APIModel | string;
+  compaction?: CompactionSettings;
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ import settings from "ep_etherpad-lite/node/utils/Settings";
 import { ExpressCreateServerArgs } from "ep_etherpad-lite/hooks";
 import { urlencoded } from "express";
 import { CompletionQuery } from "./completion/base";
+import { CompletionServiceWithCompaction } from "./completion/compaction";
 
 const logPrefix = "[ep_kodama]";
 
@@ -9,7 +10,11 @@ async function completion(query: CompletionQuery): Promise<string> {
   const pluginSettings = settings.ep_kodama || {};
   if (pluginSettings.api === "openai") {
     const { OpenAICompletionService } = require("./completion/openai");
-    const service = new OpenAICompletionService(pluginSettings);
+    const serviceCore = new OpenAICompletionService(pluginSettings);
+    const service = new CompletionServiceWithCompaction(
+      pluginSettings,
+      serviceCore
+    );
     return service.completion(query);
   }
   throw new Error(`Unknown API: ${pluginSettings.api}`);
@@ -35,7 +40,7 @@ exports.registerRoute = (
       return;
     }
     const query = JSON.parse(queryString) as CompletionQuery;
-    console.log(logPrefix, "performing completion...", query);
+    console.debug(logPrefix, "performing completion...", query);
 
     completion(query)
       .then((result) => {

--- a/src/tests/assist.test.ts
+++ b/src/tests/assist.test.ts
@@ -16,7 +16,14 @@ describe("analyzeLines", () => {
     };
     expect(analyzeLines(author, rep)).toStrictEqual({
       cursor: [0, 0],
-      query: "A: <input lines here>\n",
+      query: {
+        content: [
+          {
+            type: "text",
+            value: "A: <input lines here>\n",
+          },
+        ],
+      },
     });
   });
   test("whitespaces", () => {
@@ -33,7 +40,14 @@ describe("analyzeLines", () => {
     };
     expect(analyzeLines(author, rep)).toStrictEqual({
       cursor: [0, 0],
-      query: "A: <input lines here>    \n",
+      query: {
+        content: [
+          {
+            type: "text",
+            value: "A: <input lines here>    \n",
+          },
+        ],
+      },
     });
   });
   test("inputting", () => {

--- a/src/tests/compaction.test.ts
+++ b/src/tests/compaction.test.ts
@@ -1,0 +1,451 @@
+import { describe, expect, test } from "@jest/globals";
+import sharp from "sharp";
+import { CompletionServiceWithCompaction } from "../completion/compaction";
+import {
+  CompletionContent,
+  CompletionContentType,
+  CompletionQuery,
+} from "../completion/base";
+
+describe("trimContent", () => {
+  test("noTrimLines", async () => {
+    const pluginSettings = {
+      compaction: {
+        maxContentLength: {
+          beforeLength: 30,
+          afterLength: 30,
+        },
+      },
+    };
+    const service = new CompletionServiceWithCompaction(pluginSettings, {
+      completion: async (query: CompletionQuery) => JSON.stringify(query),
+    });
+    const contents: CompletionContent[] = [
+      {
+        type: CompletionContentType.Text,
+        value: "a".repeat(20) + "\n<input lines here>\n" + "b".repeat(20),
+      },
+    ];
+    const result = await service.completion({ content: contents });
+    const parsed = JSON.parse(result) as CompletionQuery;
+    expect(parsed.content).toHaveLength(1);
+    expect(parsed.content[0].value).toBe(
+      "a".repeat(20) + "\n<input lines here>\n" + "b".repeat(20)
+    );
+  });
+
+  test("noTrimTexts", async () => {
+    const pluginSettings = {
+      compaction: {
+        maxContentLength: {
+          beforeLength: 50,
+          afterLength: 50,
+        },
+      },
+    };
+    const service = new CompletionServiceWithCompaction(pluginSettings, {
+      completion: async (query: CompletionQuery) => JSON.stringify(query),
+    });
+    const contents: CompletionContent[] = [
+      {
+        type: CompletionContentType.Text,
+        value: "c".repeat(20),
+      },
+      {
+        type: CompletionContentType.Text,
+        value: "a".repeat(20) + "\n<input lines here>\n" + "b".repeat(20),
+      },
+      {
+        type: CompletionContentType.Text,
+        value: "d".repeat(20),
+      },
+    ];
+    const result = await service.completion({ content: contents });
+    const parsed = JSON.parse(result) as CompletionQuery;
+    expect(parsed.content).toHaveLength(3);
+    expect(parsed.content[0].value).toBe("c".repeat(20));
+    expect(parsed.content[1].value).toBe(
+      "a".repeat(20) + "\n<input lines here>\n" + "b".repeat(20)
+    );
+    expect(parsed.content[2].value).toBe("d".repeat(20));
+  });
+
+  test("trimContentLines", async () => {
+    const pluginSettings = {
+      compaction: {
+        maxContentLength: {
+          beforeLength: 10,
+          afterLength: 10,
+        },
+      },
+    };
+    const service = new CompletionServiceWithCompaction(pluginSettings, {
+      completion: async (query: CompletionQuery) => JSON.stringify(query),
+    });
+    const contents: CompletionContent[] = [
+      {
+        type: CompletionContentType.Text,
+        value: "a".repeat(20) + "\n<input lines here>\n" + "b".repeat(20),
+      },
+    ];
+    const result = await service.completion({ content: contents });
+    const parsed = JSON.parse(result) as CompletionQuery;
+    expect(parsed.content).toHaveLength(1);
+    expect(parsed.content[0].value).toBe(
+      "a".repeat(9) + "\n<input lines here>\n" + "b".repeat(9)
+    );
+  });
+
+  test("trimContentWords", async () => {
+    const pluginSettings = {
+      compaction: {
+        maxContentLength: {
+          beforeLength: 10,
+          afterLength: 10,
+        },
+      },
+    };
+    const service = new CompletionServiceWithCompaction(pluginSettings, {
+      completion: async (query: CompletionQuery) => JSON.stringify(query),
+    });
+    const contents: CompletionContent[] = [
+      {
+        type: CompletionContentType.Text,
+        value: "a".repeat(20) + "<input words here>" + "b".repeat(20),
+      },
+    ];
+    const result = await service.completion({ content: contents });
+    const parsed = JSON.parse(result) as CompletionQuery;
+    expect(parsed.content).toHaveLength(1);
+    expect(parsed.content[0].value).toBe(
+      "a".repeat(10) + "<input words here>" + "b".repeat(10)
+    );
+  });
+
+  test("trimContentTexts", async () => {
+    const pluginSettings = {
+      compaction: {
+        maxContentLength: {
+          beforeLength: 30,
+          afterLength: 30,
+        },
+      },
+    };
+    const service = new CompletionServiceWithCompaction(pluginSettings, {
+      completion: async (query: CompletionQuery) => JSON.stringify(query),
+    });
+    const contents: CompletionContent[] = [
+      {
+        type: CompletionContentType.Text,
+        value: "c".repeat(19) + "_",
+      },
+      {
+        type: CompletionContentType.Text,
+        value: "a".repeat(20) + "<input words here>" + "b".repeat(20),
+      },
+      {
+        type: CompletionContentType.Text,
+        value: "_" + "d".repeat(19),
+      },
+    ];
+    const result = await service.completion({ content: contents });
+    const parsed = JSON.parse(result) as CompletionQuery;
+    expect(parsed.content).toHaveLength(3);
+    expect(parsed.content[0].value).toBe("c".repeat(9) + "_");
+    expect(parsed.content[1].value).toBe(
+      "a".repeat(20) + "<input words here>" + "b".repeat(20)
+    );
+    expect(parsed.content[2].value).toBe("_" + "d".repeat(9));
+  });
+
+  test("trimContentTextsAndImages", async () => {
+    const imageDataBuffer = await sharp({
+      create: {
+        width: 50,
+        height: 50,
+        channels: 4,
+        background: { r: 255, g: 255, b: 255, alpha: 1 },
+      },
+    })
+      .png()
+      .toBuffer();
+    const dataURL = `data:image/png;base64,${imageDataBuffer.toString(
+      "base64"
+    )}`;
+    const pluginSettings = {
+      compaction: {
+        maxContentLength: {
+          beforeLength: 30 + dataURL.length,
+          afterLength: 30 + dataURL.length,
+        },
+      },
+    };
+    const service = new CompletionServiceWithCompaction(pluginSettings, {
+      completion: async (query: CompletionQuery) => JSON.stringify(query),
+    });
+    const contents: CompletionContent[] = [
+      {
+        type: CompletionContentType.Text,
+        value: "c".repeat(19) + "_",
+      },
+      {
+        type: CompletionContentType.Image,
+        value: dataURL,
+      },
+      {
+        type: CompletionContentType.Text,
+        value: "a".repeat(20) + "<input words here>" + "b".repeat(20),
+      },
+      {
+        type: CompletionContentType.Image,
+        value: dataURL,
+      },
+      {
+        type: CompletionContentType.Text,
+        value: "_" + "d".repeat(19),
+      },
+    ];
+    const result = await service.completion({ content: contents });
+    const parsed = JSON.parse(result) as CompletionQuery;
+    expect(parsed.content).toHaveLength(5);
+    expect(parsed.content[0].value).toBe("c".repeat(9) + "_");
+    expect(parsed.content[1].value).toBe(dataURL);
+    expect(parsed.content[2].value).toBe(
+      "a".repeat(20) + "<input words here>" + "b".repeat(20)
+    );
+    expect(parsed.content[3].value).toBe(dataURL);
+    expect(parsed.content[4].value).toBe("_" + "d".repeat(9));
+  });
+
+  test("trimContentTextsAndLargeImages", async () => {
+    const imageDataBuffer = await sharp({
+      create: {
+        width: 50,
+        height: 50,
+        channels: 4,
+        background: { r: 255, g: 255, b: 255, alpha: 1 },
+      },
+    })
+      .png()
+      .toBuffer();
+    const dataURL = `data:image/png;base64,${imageDataBuffer.toString(
+      "base64"
+    )}`;
+    const pluginSettings = {
+      compaction: {
+        maxContentLength: {
+          beforeLength: 30 + dataURL.length,
+          afterLength: 30 + dataURL.length,
+        },
+      },
+    };
+    const service = new CompletionServiceWithCompaction(pluginSettings, {
+      completion: async (query: CompletionQuery) => JSON.stringify(query),
+    });
+    const contents: CompletionContent[] = [
+      {
+        type: CompletionContentType.Image,
+        value: dataURL,
+      },
+      {
+        type: CompletionContentType.Text,
+        value: "c".repeat(19) + "_",
+      },
+      {
+        type: CompletionContentType.Text,
+        value: "a".repeat(20) + "<input words here>" + "b".repeat(20),
+      },
+      {
+        type: CompletionContentType.Text,
+        value: "_" + "d".repeat(19),
+      },
+      {
+        type: CompletionContentType.Image,
+        value: dataURL,
+      },
+    ];
+    const result = await service.completion({ content: contents });
+    const parsed = JSON.parse(result) as CompletionQuery;
+    expect(parsed.content).toHaveLength(3);
+    expect(parsed.content[0].value).toBe("c".repeat(19) + "_");
+    expect(parsed.content[1].value).toBe(
+      "a".repeat(20) + "<input words here>" + "b".repeat(20)
+    );
+    expect(parsed.content[2].value).toBe("_" + "d".repeat(19));
+  });
+});
+
+describe("resizeImage", () => {
+  test("noResize", async () => {
+    const pluginSettings = {
+      compaction: {
+        maxImageSize: {
+          width: 100,
+          height: 100,
+        },
+      },
+    };
+    const service = new CompletionServiceWithCompaction(pluginSettings, {
+      completion: async (query: CompletionQuery) => JSON.stringify(query),
+    });
+    const imageDataBuffer = await sharp({
+      create: {
+        width: 50,
+        height: 50,
+        channels: 4,
+        background: { r: 255, g: 255, b: 255, alpha: 1 },
+      },
+    })
+      .png()
+      .toBuffer();
+    const dataURL = `data:image/png;base64,${imageDataBuffer.toString(
+      "base64"
+    )}`;
+    const contents: CompletionContent[] = [
+      {
+        type: CompletionContentType.Image,
+        value: dataURL,
+      },
+    ];
+    const result = await service.completion({ content: contents });
+    const parsed = JSON.parse(result) as CompletionQuery;
+    expect(parsed.content).toHaveLength(1);
+    expect(parsed.content[0].value).toBe(dataURL);
+  });
+
+  test("resize", async () => {
+    const pluginSettings = {
+      compaction: {
+        maxImageSize: {
+          width: 100,
+          height: 100,
+        },
+      },
+    };
+    const service = new CompletionServiceWithCompaction(pluginSettings, {
+      completion: async (query: CompletionQuery) => JSON.stringify(query),
+    });
+    const imageDataBuffer = await sharp({
+      create: {
+        width: 200,
+        height: 200,
+        channels: 4,
+        background: { r: 255, g: 255, b: 255, alpha: 1 },
+      },
+    })
+      .png()
+      .toBuffer();
+    const dataURL = `data:image/png;base64,${imageDataBuffer.toString(
+      "base64"
+    )}`;
+    const contents: CompletionContent[] = [
+      {
+        type: CompletionContentType.Image,
+        value: dataURL,
+      },
+    ];
+    const result = await service.completion({ content: contents });
+    const parsed = JSON.parse(result) as CompletionQuery;
+    expect(parsed.content).toHaveLength(1);
+    expect(parsed.content[0].value).not.toBe(dataURL);
+
+    const resizedBuffer = Buffer.from(
+      parsed.content[0].value.split(",")[1],
+      "base64"
+    );
+    const metadata = await sharp(resizedBuffer).metadata();
+    expect(metadata.width).toBe(100);
+    expect(metadata.height).toBe(100);
+  });
+
+  test("resizeWithAspectRatio", async () => {
+    const pluginSettings = {
+      compaction: {
+        maxImageSize: {
+          width: 100,
+          height: 100,
+        },
+      },
+    };
+    const service = new CompletionServiceWithCompaction(pluginSettings, {
+      completion: async (query: CompletionQuery) => JSON.stringify(query),
+    });
+    const imageDataBuffer = await sharp({
+      create: {
+        width: 200,
+        height: 50,
+        channels: 4,
+        background: { r: 255, g: 255, b: 255, alpha: 1 },
+      },
+    })
+      .png()
+      .toBuffer();
+    const dataURL = `data:image/png;base64,${imageDataBuffer.toString(
+      "base64"
+    )}`;
+    const contents: CompletionContent[] = [
+      {
+        type: CompletionContentType.Image,
+        value: dataURL,
+      },
+    ];
+    const result = await service.completion({ content: contents });
+    const parsed = JSON.parse(result) as CompletionQuery;
+    expect(parsed.content).toHaveLength(1);
+    expect(parsed.content[0].value).not.toBe(dataURL);
+
+    const resizedBuffer = Buffer.from(
+      parsed.content[0].value.split(",")[1],
+      "base64"
+    );
+    const metadata = await sharp(resizedBuffer).metadata();
+    expect(metadata.width).toBe(100);
+    expect(metadata.height).toBe(25);
+  });
+
+  test("resizeJPEG", async () => {
+    const pluginSettings = {
+      compaction: {
+        maxImageSize: {
+          width: 100,
+          height: 100,
+        },
+      },
+    };
+    const service = new CompletionServiceWithCompaction(pluginSettings, {
+      completion: async (query: CompletionQuery) => JSON.stringify(query),
+    });
+    const imageDataBuffer = await sharp({
+      create: {
+        width: 200,
+        height: 200,
+        channels: 3,
+        background: { r: 255, g: 255, b: 255 },
+      },
+    })
+      .jpeg()
+      .toBuffer();
+    const dataURL = `data:image/jpeg;base64,${imageDataBuffer.toString(
+      "base64"
+    )}`;
+    const contents: CompletionContent[] = [
+      {
+        type: CompletionContentType.Image,
+        value: dataURL,
+      },
+    ];
+    const result = await service.completion({ content: contents });
+    const parsed = JSON.parse(result) as CompletionQuery;
+    expect(parsed.content).toHaveLength(1);
+    expect(parsed.content[0].value).not.toBe(dataURL);
+
+    expect(parsed.content[0].value).toMatch(/^data:image\/png;base64,/);
+    const resizedBuffer = Buffer.from(
+      parsed.content[0].value.split(",")[1],
+      "base64"
+    );
+    const metadata = await sharp(resizedBuffer).metadata();
+    expect(metadata.width).toBe(100);
+    expect(metadata.height).toBe(100);
+  });
+});


### PR DESCRIPTION
Supported image resizing and content cropping to control the amount of data sent to the LLM.

```
  "ep_kodama": {
    ...
    "compaction": {
      "maxImageSize": {
        "width": 480,
        "height": 480
      },
      "maxContentLength": {
        "beforeLength": 20480,
        "afterLength": 1024
      }
    }
  }

```

You can set the maximum size of the images and the content length before and after marker in the "compaction" section of the configuration.

- maxImageSize ... determines the maximum dimensions (width and height in pixels) to which images will be resized before being sent to the LLM.
- maxContentLength ... controls the length of the content sent before and after the marker. 'beforeLength' dictates the maximum amount of data(in String.length) sent before the marker, whereas 'afterLength' defines the maximum length of the data following the marker. When the data exceeds these limits, it will be trimmed to fit accordingly.