### PR TITLE
Upgrade the default api model to GPT-4o

### DIFF
--- a/demo/settings.json
+++ b/demo/settings.json
@@ -655,8 +655,8 @@
   "ep_kodama": {
     "api": "openai",
     "apiModel": {
-      "default": "gpt-4",
-      "forImage": "gpt-4-vision-preview"
+      "default": "gpt-4o",
+      "forImage": "gpt-4o"
     },
     "apiKey": "DUMMY_TOKEN",
     "compaction": {


### PR DESCRIPTION
Upgrade the default api model to GPT-4o. The change was made in response to [the news about GPT-4o](https://openai.com/index/hello-gpt-4o/).