### PR TITLE
Add Gemini API support

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,10 +84,8 @@ To reduce the number of tokens sent to the LLM, ep_kodama can shorten text and r
     }
 ```
 
-- **maxImageSize**: This setting controls the maximum size of images sent to the LLM. If the image is larger than this size, it will be resized to fit within these dimensions.
-- **maxContentLength**: This setting controls the maximum length of text sent to the LLM.
-  - **beforeLength**: This is the maximum length of the text before the cursor.
-  - **afterLength**: This is the maximum length of the text after the cursor.
+- **maxImageSize**: determines the maximum dimensions (width and height in pixels) to which images will be resized before being sent to the LLM.
+- **maxContentLength**: controls the length of the content sent before and after the marker. 'beforeLength' dictates the maximum amount of data(in String.length) sent before the marker, whereas 'afterLength' defines the maximum length of the data following the marker. When the data exceeds these limits, it will be trimmed to fit accordingly.
 
 ### Completion
 

--- a/README.md
+++ b/README.md
@@ -67,6 +67,25 @@ Remember to replace `"your-api-key"` with your actual OpenAI API key. Save and c
 
 After install the plugin, restart the Etherpad service for the changes to take effect. Once restarted, the ep_kodama plugin should be active and ready to use.
 
+### Using Gemini
+
+ep_kodama also supports Google's Gemini API. To use it, set the `api` field to "gemini" and set the `apiKey` field to your API key.
+
+```
+  "ep_kodama": {
+    "api": "gemini",
+    "apiModel": "gemini-1.5-flash",
+    "apiKey": "your-api-key",
+    ...
+  }
+```
+
+For Gemini, also replace `"your-api-key"` with your actual API key of Google AI Studio. You can obtain an API key from the following link:
+
+https://aistudio.google.com/app/apikey
+
+After restarting the Etherpad service, ep_kodama should be ready to use with the Gemini API.
+
 ### Compaction
 
 To reduce the number of tokens sent to the LLM, ep_kodama can shorten text and reduce the size of images. This feature can be controlled using the `compaction` setting.

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "ep_kodama",
       "version": "0.1.4",
       "dependencies": {
+        "@google/generative-ai": "^0.12.0",
         "express": "^4.19.2",
         "ms": "^2.1.3",
         "node-fetch": "^3.3.2",
@@ -1168,6 +1169,14 @@
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@google/generative-ai": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@google/generative-ai/-/generative-ai-0.12.0.tgz",
+      "integrity": "sha512-krWjurjEUHSFhCX4lGHMOhbnpBfYZGU31mpHpPBQwcfWm0T+/+wxC4UCAJfkxxc3/HvGJVG8r4AqrffaeDHDlA==",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@humanwhocodes/config-array": {

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   },
   "contributors": [],
   "dependencies": {
+    "@google/generative-ai": "^0.12.0",
     "express": "^4.19.2",
     "ms": "^2.1.3",
     "node-fetch": "^3.3.2",

--- a/src/completion/gemini.ts
+++ b/src/completion/gemini.ts
@@ -1,0 +1,92 @@
+import { GoogleGenerativeAI } from "@google/generative-ai";
+import { PluginSettings } from "./settings";
+import {
+  CompletionContent,
+  CompletionContentType,
+  CompletionQuery,
+} from "./base";
+import { APIModel } from "ep_etherpad-lite/node/utils/Settings";
+
+const logPrefix = "[ep_kodama]";
+
+type GenAIPrompt =
+  | string
+  | {
+      inlineData: {
+        data: string;
+        mimeType: string;
+      };
+    };
+
+function convertCompletionContent(content: CompletionContent): GenAIPrompt {
+  switch (content.type) {
+    case CompletionContentType.Text:
+      return content.value;
+    case CompletionContentType.Image:
+      // if the content is not a data URL, return it as is
+      if (!content.value.startsWith("data:")) {
+        return content.value;
+      }
+      // if the content is a data URL, extract the data and mimeType
+      const dataURL = content.value;
+      const buffer = Buffer.from(dataURL.split(",")[1], "base64");
+      const mimeType = dataURL.split(",")[0].split(":")[1].split(";")[0];
+      return {
+        inlineData: {
+          data: buffer.toString("base64"),
+          mimeType,
+        },
+      };
+    default:
+      throw new Error(`Unsupported content type: ${content.type}`);
+  }
+}
+
+export class GeminiCompletionService {
+  private pluginSettings: PluginSettings;
+
+  constructor(pluginSettings: PluginSettings) {
+    this.pluginSettings = pluginSettings;
+  }
+
+  async completion(query: CompletionQuery): Promise<string> {
+    if (this.pluginSettings.apiKey === undefined) {
+      throw new Error("API key is required");
+    }
+    const genAI = new GoogleGenerativeAI(this.pluginSettings.apiKey);
+    const { apiModel } = this.pluginSettings;
+    if (apiModel === undefined) {
+      throw new Error("API model is required");
+    }
+    if (typeof apiModel !== "string") {
+      throw new Error("API model must be a string");
+    }
+    const model = genAI.getGenerativeModel({
+      model: apiModel,
+    });
+
+    console.debug(logPrefix, "Gemini model:", apiModel);
+    console.debug(logPrefix, "Query:", query);
+    const prompt = `
+    You are a writing assistance agent. You take as input a text in the process of being written and suggest appropriate words to be written.
+    The text contains a single marker <input (words|lines) here>. Follow the rules below to generate the string that should be placed there with consideration of the context before and after and return only that string.
+    
+    - <input words here>: Generate a string that should be placed in this marker. Generate text that makes sense together with the preceding text and the text in the marker to make a single sentence.
+    - <input lines here>: Generate about 1-3 sentences of lines that should be inserted in this marker.
+    
+    Note that a.XXX means the author of the statement.
+    The language should be selected appropriately for the text entered.
+    If an image is attached as part of the input, please consider the content of that image in your suggestion.
+    The result text should not include any preceding or following text, and should not be highlighted in Markdown.
+    `;
+
+    const result = await model.generateContent(
+      [prompt as GenAIPrompt].concat(
+        query.content.map((c) => convertCompletionContent(c))
+      )
+    );
+    const text = result.response.text();
+    console.debug("Gemini response:", text);
+    return text;
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,15 @@ async function completion(query: CompletionQuery): Promise<string> {
     );
     return service.completion(query);
   }
+  if (pluginSettings.api === "gemini") {
+    const { GeminiCompletionService } = require("./completion/gemini");
+    const serviceCore = new GeminiCompletionService(pluginSettings);
+    const service = new CompletionServiceWithCompaction(
+      pluginSettings,
+      serviceCore
+    );
+    return service.completion(query);
+  }
   throw new Error(`Unknown API: ${pluginSettings.api}`);
 }
 


### PR DESCRIPTION
Add Gemini API support. To use it, set the `api` field to "gemini" and set the `apiKey` field to your API key.

```
  "ep_kodama": {
    "api": "gemini",
    "apiModel": "gemini-1.5-flash",
    "apiKey": "your-api-key",
    ...
  }
```

For Gemini, also replace `"your-api-key"` with your actual API key of Google AI Studio. You can obtain an API key from the following link:

https://aistudio.google.com/app/apikey
