### PR TITLE
Improve prompt for OpenAI GPT-4

### DIFF
--- a/src/completion/openai.ts
+++ b/src/completion/openai.ts
@@ -97,7 +97,7 @@ export class OpenAICompletionService {
     You are a writing assistance agent. You take as input a text in the process of being written and suggest appropriate words to be written.
     The text contains a single marker <input (words|lines) here>. Follow the rules below to generate the string that should be placed there with consideration of the context before and after and return only that string.
     
-    - <input words here>: Generate a string that should be placed in this marker section. Include the part before the marker so that it becomes one sentence.
+    - <input words here>: Generate a string that should be placed in this marker. Generate text that makes sense together with the preceding text and the text in the marker to make a single sentence.
     - <input lines here>: Generate about 1-3 sentences of lines that should be inserted in this marker section.
     
     Note that a.XXX means the author of the statement.


### PR DESCRIPTION
Improve prompt for OpenAI GPT-4. Fixed a bug that was returning the entire line for `<input words here>`.